### PR TITLE
Fix issue in helm-proc-action-gdb

### DIFF
--- a/helm-proc.el
+++ b/helm-proc.el
@@ -233,13 +233,13 @@ Return a list of pids as result."
 
 (defun helm-proc-action-gdb (pid)
   "Attach gdb to PID."
-  (setq
-   gud-gdb-command-name
-   (format
-    "gdb -i=mi %s %s"
-    (file-truename
-     (format "/proc/%s/exe" pid))
-    pid))
+  (add-to-list
+    'gud-gdb-history
+    (format
+     "gdb -i=mi %s %s"
+     (file-truename
+      (format "/proc/%s/exe" pid))
+     pid))
   (call-interactively 'gdb))
 
 (defun helm-proc-run-kill ()


### PR DESCRIPTION
When calling helm-proc-action-gdb append the desired gdb command to
gud-gdb-history instead of setting gud-gdb-command-name. The reason
for this is that executing M-x gdb (which is whas helm-proc-action-gdb
does), gud-gdb-command-name is never considered unless gud-gdb-history
is empty.