### PR TITLE
Remove outdated helm-proc-pkg.el

### DIFF
--- a/helm-proc-pkg.el
+++ b/helm-proc-pkg.el
@@ -1,3 +1,0 @@
-(define-package "helm-proc" "0.0.1"
-  "Helm interface for managing system processes"
-  '((helm "1.6.0")))


### PR DESCRIPTION
The information in `<name>-pkg.el` did not agree with the information in `<name>.el`.  This pull-requests addresses that be removing the outdated `<name>-pkg.el`.

While the end-user package manager `package.el` expects a file `<name>-pkg.el`, this should only be generate by the package archive (such as GNU ELPA and MELPA), instead of being tracked in the upstream repository.

The tools used maintain the various *ELPA, do *not* use `<name>-pkg.el` as a data *source*, they only generate it.

- `elpa-admin.el`, the tool used for GNU ELPA and NonGNU ELPA, does *not* use `<name>-pkg.el` as a data source and it never has.

- `package-build.el`, the tool used for Melpa, prefers `<name>.el` but *currently* falls back to get information missing from there from `<name>-pkg.el` instead. I am goint to change that; soon `<name>-pkg.el` will be ignored as a data source by this tool too.